### PR TITLE
Fix/avoid expcetions on node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 before_install:
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 script:
-  - npm run check && TRAVIS_TAG=$TRAVIS_TAG GH_TOKEN=$GH_TOKEN npm run versiona
+  - npm run check && npm run versiona
   - npm run coverage:ci
 
 after_success:

--- a/src/integration-test/PikoTest.js
+++ b/src/integration-test/PikoTest.js
@@ -2,6 +2,7 @@ import {JSDOM} from 'jsdom'
 import {expect} from 'chai'
 import sinon from 'sinon'
 import Piko from '../main/index'
+import {DEFAULT_LEVEL} from '../main/domain/constants'
 
 describe('Piko', () => {
   const dom = new JSDOM('<!DOCTYPE html><body></body>', {
@@ -334,6 +335,17 @@ describe('Piko', () => {
       expect(errorSpy.args[0][0]).to.equal('FATAL | test | ')
       expect(errorSpy.args[0][1]).to.equal(aFatalMessage)
       expect(errorSpy.args[0][2]).to.equal(error)
+    })
+    it('should not fail on invalid configured level', () => {
+      const key1 = 'key1'
+      const key2 = 'key2'
+      window.localStorage.setItem('piko.level.key1', undefined)
+      window.localStorage.setItem('piko.level.key2', 'invent')
+      const logger1 = Piko.logger(key1)
+      const logger2 = Piko.logger(key2)
+
+      expect(logger1._level._level).to.equal(DEFAULT_LEVEL)
+      expect(logger2._level._level).to.equal(DEFAULT_LEVEL)
     })
   })
 })

--- a/src/main/domain/Level.js
+++ b/src/main/domain/Level.js
@@ -9,15 +9,13 @@ export class Level {
   _getLevel() {
     if (typeof window !== 'undefined') {
       try {
-        return (
+        const value =
           window.localStorage.getItem(`${LOCAL_STORAGE_KEY}.${this._key}`) ||
-          window.localStorage.getItem(LOCAL_STORAGE_KEY) ||
-          DEFAULT_LEVEL
-        )
-      } catch {
-        return DEFAULT_LEVEL
-      }
+          window.localStorage.getItem(LOCAL_STORAGE_KEY)
+        return (!!LEVEL[value] && value) || DEFAULT_LEVEL
+      } catch {}
     }
+    return DEFAULT_LEVEL
   }
 
   shouldLogTrace() {


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Running tests with files importing the piko logger ends in error because it never returns a value if window is undefined.

This PR modifies it to return the "off" level in that case.
## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/VBVY9IJKDxwHK/giphy.gif)